### PR TITLE
fix: ps stdout with utf8 encoding

### DIFF
--- a/src/main/monitor/ps.ts
+++ b/src/main/monitor/ps.ts
@@ -69,7 +69,7 @@ export function listProcesses(rootPid: number): Promise<Map<number, ProcessItem>
           const args = '-ax -o pid=,ppid=,pcpu=,pmem=,command=';
 
           // Set numeric locale to ensure '.' is used as the decimal separator
-          exec(`${ps} ${args}`, { maxBuffer: 1000 * 1024, env: { LC_NUMERIC: 'en_US.UTF-8' } }, (err, stdout, stderr) => {
+          exec(`${ps} ${args}`, { maxBuffer: 1000 * 1024, env: { ...process.env, LC_NUMERIC: 'en_US.UTF-8' } }, (err, stdout, stderr) => {
             // Silently ignoring the screen size is bogus error. See https://github.com/microsoft/vscode/issues/98590
             if (err || (stderr && !stderr.includes('screen size is bogus'))) {
               reject(err || new Error(stderr.toString()));


### PR DESCRIPTION
1. 修复 *nix 输出内容如果有CJK会乱码
<img width="1244" alt="image" src="https://user-images.githubusercontent.com/2226423/167326128-3beedfc5-03cf-4d7c-8463-b5d974220972.png">
