### PR TITLE
chore: upgrade mkdirp, in case of security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "debug": "4",
     "filesize": "6",
     "lodash": "4",
-    "mkdirp": "0.5.1",
+    "mkdirp": "1.0.4",
     "moment": "2"
   },
   "devDependencies": {


### PR DESCRIPTION
Prototype Pollution in minimist - https://github.com/advisories/GHSA-vh95-rmgr-6w4m
Prototype Pollution in minimist - https://github.com/advisories/GHSA-xvch-5gv4-984h

use mkdirp 1.x, which no longer depends on minimist